### PR TITLE
feat(*): add chart memcached

### DIFF
--- a/alpine/Chart.yaml
+++ b/alpine/Chart.yaml
@@ -1,4 +1,4 @@
-name: alpine-pod
+name: alpine
 home: http://github.com/deis/helm
 version: 0.0.1
 description: Simple pod running Alpine Linux.

--- a/alpine/README.md
+++ b/alpine/README.md
@@ -1,3 +1,8 @@
 # Alpine
 
 This Chart provides a Pod running Alpine Linux.
+
+## Usage
+
+This pod is for testing and debugging. The standard usage is to connect
+using `kubectl exec` and then install the tools you want using `apk`.

--- a/memcached/Chart.yaml
+++ b/memcached/Chart.yaml
@@ -1,0 +1,9 @@
+name: memcached
+home: http://https://hub.docker.com/_/memcached/
+version: 0.1.0
+description: A simple Memcached cluster
+maintainers:
+- Matt Butcher <mbutcher@deis.com>
+details: |-
+  Memcached is a simple cache server. This chart provides multiple replication
+  controllers that can be grouped together into a cluster.

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -1,0 +1,20 @@
+# memcached
+
+Memcached is a cache server. http://memcached.org/
+
+This chart provides a replication controller that starts (by default) a
+single Memcached server. Memcached's clustering model is very simple:
+everything is done client-side.
+
+## For Clustering
+
+This project creates two memcached RCs, each with only one pod. To use
+this cluster, an app should declare two services -- one for each RC.
+Memcached clients should then be configured to use both services.
+
+RCs are named `memcached-1` and `memcached-2`. Both are labeled with
+`provider: memcached`. However, using that as your only label selector
+will have undesirable consequences.
+
+To add more memcached servers to the cluster, create additional RCs and
+services.

--- a/memcached/manifests/memcached-rc.yaml
+++ b/memcached/manifests/memcached-rc.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: memcached-1
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: memcached-1
+    mode: cluster
+    provider: memcached
+  template:
+    metadata:
+      labels:
+        name: memcached-1
+        mode: cluster
+        provider: memcached
+    spec:
+      containers:
+      - name: memcached
+        image: "memcached:1.4.24"
+        ports:
+        - containerPort: 11211
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: memcached-2
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: memcached-2
+    mode: cluster
+    provider: memcached
+  template:
+    metadata:
+      labels:
+        name: memcached-2
+        mode: cluster
+        provider: memcached
+    spec:
+      containers:
+      - name: memcached
+        image: "memcached:1.4.24"
+        ports:
+        - containerPort: 11211


### PR DESCRIPTION
This adds a chart for starting two memcached servers (as separate RCs).

Memcached clustering is weird. It's done client-side. So this creates two disjoined RCs and relies on consumers to create services (one for each RC) and then use the cluster.
