### PR TITLE
[WIP] feat(deis): add deis v2 chart

### DIFF
--- a/deis/Chart.yaml
+++ b/deis/Chart.yaml
@@ -1,0 +1,13 @@
+name: deis
+home: https://github.com/deis/workflow
+version: 2.0.0-pre-alpha
+description: For testing only!
+maintainers:
+- Matt Boersma <mboersma@deis.com>
+details: |-
+  WARNING: this chart is for testing only! Features may not work, the
+  components are not HA, and there are likely to be bugs.
+
+  Deis (pronounced DAY-iss) is an open source PaaS that makes it easy to deploy
+  and manage applications on your own servers. Deis builds on Kubernetes
+  to provide a lightweight, Heroku-inspired workflow.

--- a/deis/README.md
+++ b/deis/README.md
@@ -1,0 +1,11 @@
+# Deis v2.0.0-pre-alpha
+
+WARNING: this chart is for testing only! Features may not work, the
+components are not HA, and there are likely to be bugs.
+
+Please report any issues you find in testing Deis v2 on Kubernetes
+to the appropriate GitHub repository:
+- chart: https://github.com/deis/charts
+- helm: https://github.com/deis/helm
+- workflow: https://github.com/deis/workflow
+- etcd: https://github.com/deis/etcd

--- a/deis/manifests/deis-database-rc.yaml
+++ b/deis/manifests/deis-database-rc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-database
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: deis-database
+  template:
+    metadata:
+      labels:
+        name: deis-database
+    spec:
+      containers:
+        - name: deis-database
+          image: postgres:9.3
+          env:
+            - name: POSTGRES_USER
+              value: "deis"
+            - name: POSTGRES_PASSWORD
+              value: "changeme123"
+          ports:
+            - containerPort: 5432

--- a/deis/manifests/deis-database-service.yaml
+++ b/deis/manifests/deis-database-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-database
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: http
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    name: deis-database

--- a/deis/manifests/deis-etcd-discovery-rc.yaml
+++ b/deis/manifests/deis-etcd-discovery-rc.yaml
@@ -1,0 +1,35 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery
+  labels:
+    name: deis-etcd-discovery
+spec:
+  replicas: 1
+  selector:
+    name: deis-etcd-discovery
+  template:
+    metadata:
+      labels:
+        name: deis-etcd-discovery
+    spec:
+      volumes:
+        - name: discovery-token
+          secret:
+            secretName: deis-etcd-discovery-token
+      containers:
+        - name: deis-etcd-discovery
+          image: quay.io/deis/etcd
+          command:
+            - /usr/local/bin/discovery
+          ports:
+            - containerPort: 2381
+          env:
+            - name: DEIS_ETCD_CLUSTER_SIZE
+              value: "3"
+            - name: ETCD_LISTEN_CLIENT_URLS
+              value: http://0.0.0.0:2381
+          volumeMounts:
+            - name: discovery-token
+              readOnly: true
+              mountPath: /var/run/secrets/deis/etcd/discovery

--- a/deis/manifests/deis-etcd-discovery-service.yaml
+++ b/deis/manifests/deis-etcd-discovery-service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery
+  labels:
+    name: deis-etcd-discovery
+    app: deis
+spec:
+  ports:
+    - name: client
+      port: 2381
+      targetPort: 2381
+      protocol: TCP
+  selector:
+    name: deis-etcd-discovery

--- a/deis/manifests/deis-etcd-discovery-token.yaml
+++ b/deis/manifests/deis-etcd-discovery-token.yaml
@@ -1,0 +1,6 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery-token
+data:
+  token: "RTJENjQ1NzYtRDU0Ny00OThDLUFGNzEtM0NGNkVGMzE5QThCCg=="

--- a/deis/manifests/deis-etcd-rc.yaml
+++ b/deis/manifests/deis-etcd-rc.yaml
@@ -1,0 +1,31 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: deis-etcd-1
+  labels:
+    name: deis-etcd-1
+spec:
+  replicas: 3
+  selector:
+    name: deis-etcd-1
+  template:
+    metadata:
+      labels:
+        name: deis-etcd-1
+    spec:
+      volumes:
+        - name: discovery-token
+          secret:
+            secretName: deis-etcd-discovery-token
+      containers:
+        - name: deis-etcd-1
+          image: quay.io/deis/etcd
+          env:
+            - name: DEIS_ETCD_CLUSTER_SIZE
+              value: "3"
+            - name: ETCD_NAME
+              value: deis1
+          volumeMounts:
+            - name: discovery-token
+              readOnly: true
+              mountPath: /var/run/secrets/deis/etcd/discovery

--- a/deis/manifests/deis-etcd-service.yaml
+++ b/deis/manifests/deis-etcd-service.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: deis-etcd-1
+  labels:
+    name: deis-etcd-1
+    app: deis
+spec:
+  ports:
+    - name: peer
+      port: 2380
+      protocol: TCP
+    - name: client
+      port: 4100
+      targetPort: 4100
+      protocol: TCP
+  selector:
+    name: deis-etcd-1

--- a/deis/manifests/deis-registry-rc.yaml
+++ b/deis/manifests/deis-registry-rc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-registry
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: deis-registry
+  template:
+    metadata:
+      labels:
+        name: deis-registry
+    spec:
+      containers:
+        - name: deis-registry
+          image: registry:2
+          env:
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "true"
+            - name: REGISTRY_LOG_LEVEL
+              value: info
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: registry-storage
+              mountPath: /var/lib/registry
+      volumes:
+        - name: registry-storage
+          emptyDir: {}

--- a/deis/manifests/deis-registry-service.yaml
+++ b/deis/manifests/deis-registry-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-registry
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: http
+      port: 5000
+      targetPort: 5000
+      protocol: TCP
+  selector:
+    name: deis-registry

--- a/deis/manifests/deis-workflow-rc.yaml
+++ b/deis/manifests/deis-workflow-rc.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-workflow
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: deis-workflow
+  template:
+    metadata:
+      labels:
+        name: deis-workflow
+    spec:
+      containers:
+        - name: deis-workflow
+          image: quay.io/deis/workflow
+          env:
+            - name: DEIS_DATABASE_USER
+              value: deis
+            - name: DEIS_DATABASE_PASSWORD
+              value: changeme123
+          ports:
+            - containerPort: 8000
+              name: http
+          volumeMounts:
+            - mountPath: /var/run/docker.sock
+              name: docker-socket
+      volumes:
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock

--- a/deis/manifests/deis-workflow-service.yaml
+++ b/deis/manifests/deis-workflow-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-workflow
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      protocol: TCP
+  selector:
+    name: deis-workflow


### PR DESCRIPTION
**NOTE**: This PR belongs over in deis/charts, so it will move there (eventually).

This is a first attempt at making a chart for Deis v2:

``` console
$ helm install deis
---> Running `kubectl create -f` ...
secret "deis-etcd-discovery-token" created
service "deis-database" created
service "deis-etcd-discovery" created
service "deis-etcd-1" created
service "deis-registry" created
service "deis-workflow" created
replicationcontroller "deis-database" created
replicationcontroller "deis-etcd-discovery" created
replicationcontroller "deis-etcd-1" created
replicationcontroller "deis-registry" created
replicationcontroller "deis-workflow" created
---> Done
========================================
# Deis v2.0.0-pre-alpha

WARNING: this chart is for testing only! Features may not work, the
components are not HA, and there are likely to be bugs.

Please report any issues you find in testing Deis v2 on Kubernetes
to the appropriate GitHub repository:
- chart: https://github.com/deis/charts
- helm: https://github.com/deis/helm
- workflow: https://github.com/deis/workflow
- etcd: https://github.com/deis/etcd
========================================
$ kubectl get pod
NAME                        READY     STATUS    RESTARTS   AGE
deis-database-37am7         1/1       Running   0          1m
deis-etcd-1-04mdu           1/1       Running   1          1m
deis-etcd-1-d2s3o           1/1       Running   2          1m
deis-etcd-1-pyzzy           1/1       Running   2          1m
deis-etcd-discovery-wmd93   1/1       Running   0          1m
deis-registry-vpbli         1/1       Running   0          1m
deis-workflow-cy382         1/1       Running   0          1m
$ kubectl logs deis-workflow-cy382
...
[2015-11-14 22:27:39 +0000] [188] [INFO] Booting worker with pid: 188
[2015-11-14 22:27:39 +0000] [189] [INFO] Booting worker with pid: 189
Done Publishing DB state to etcd.
deis-controller running...
$ helm publish deis  # w00t for small victories
```

There is much development in the components and infrastructure still needed, but the charts repo seemed like the appropriate place for this to land. (You can `helm repo add` my fork to test this chart.) Hopefully we can use this to coordinate development of Deis v2 alpha.

If you ssh to your k8s minion node after bringing this up, you can test (most of) a `deis pull` workflow:

``` console
$ curl -sSL http://deis.io/deis-cli/install.sh | sh
$ mkdir $HOME/bin && mv deis $HOME/bin
$ kubectl get service deis-workflow
$ deis register 10.247.59.157:8000  # or the appropriate CLUSTER_IP
$ ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
$ eval $(ssh-agent) && ssh-add ~/.ssh/id_rsa
$ deis keys:add ~/.ssh/id_rsa.pub
$ deis create --no-remote
Creating Application... done, created madras-radiator
$ deis pull deis/example-go -a madras-radiator
Creating build... ..o
```

cc: @bacongobbler @gabrtv @sgoings.
