### PR TITLE
style(selenium): remove duplicate data

### DIFF
--- a/selenium/manifests/selenium-hub-svc.yaml
+++ b/selenium/manifests/selenium-hub-svc.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,8 +7,7 @@ metadata:
     heritage: helm
 spec:
   ports:
-  - port: 4444 
-    targetPort: 4444 
+  - port: 4444
     name: port0
   selector:
     app: selenium-hub


### PR DESCRIPTION
when targetPort is not supplied, it is implied to be the same as
"port". The line at the beginning is not required, either.
