### PR TITLE
Add selector to Cassandra RC

### DIFF
--- a/cassandra/Chart.yaml
+++ b/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 name: cassandra
 home: http://cassandra.apache.org/
-version: 0.2.0
+version: 0.2.1
 description: The Apache Cassandra Project.
 maintainers:
   - Matt Fisher <mfisher@deis.com>

--- a/cassandra/manifests/cassandra-rc.yaml
+++ b/cassandra/manifests/cassandra-rc.yaml
@@ -7,7 +7,13 @@ metadata:
     heritage: helm
 spec:
   replicas: 1
+  selector:
+    provider: cassandra
   template:
+    metadata:
+      name: cassandra
+      labels:
+        provider: cassandra
     spec:
       containers:
       - name: cassandra


### PR DESCRIPTION
RC was malformed, missing the spec.selector field. Add this,
and bump the point version of the Chart.

Fixes #44.
