### PR TITLE
feat(*): add ubuntu-debootstrap chart

### DIFF
--- a/ubuntu-debootstrap/Chart.yaml
+++ b/ubuntu-debootstrap/Chart.yaml
@@ -1,0 +1,9 @@
+name: ubuntu-debootstrap
+home: https://hub.docker.com/_/ubuntu-debootstrap/
+version: 0.0.1
+description: Simple pod running minimal Ubuntu
+maintainers:
+  - Matt Butcher <mbutcher@deis.com>
+details:
+  This package runs a minimal Linux environment based on
+  ubuntu-debootstrap.

--- a/ubuntu-debootstrap/README.md
+++ b/ubuntu-debootstrap/README.md
@@ -1,0 +1,8 @@
+# Ubuntu Debootstrap
+
+This Chart provides a Pod running Ubuntu.
+
+## Usage
+
+This pod is for testing and debugging. The standard usage is to connect
+using `kubectl exec` and then install the tools you want using `apt-get`.

--- a/ubuntu-debootstrap/manifests/ubuntu-pod.yaml
+++ b/ubuntu-debootstrap/manifests/ubuntu-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubuntu
+  labels:
+    heritage: helm
+spec:
+  restartPolicy: Never
+  containers:
+  - name: waiter
+    image: "ubuntu-debootstrap:15.10"
+    command: ["/bin/sleep","9000"]


### PR DESCRIPTION
This adds a simple Ubuntu chart useful for debugging. It's similar to Alpine, but using ubuntu-debootstrap instead.
