### PR TITLE
fix(elasticsearch-1): name pod properly for tests

### DIFF
--- a/elasticsearch-1/manifests/elasticsearch-rc.yaml
+++ b/elasticsearch-1/manifests/elasticsearch-rc.yaml
@@ -11,7 +11,7 @@ spec:
     provider: elasticsearch
   template:
     metadata:
-      name: elasticsearch
+      name: elasticsearch-1
       labels:
         provider: elasticsearch
     spec:


### PR DESCRIPTION
Merging #60 inadvertently broke automated testing:

```
========================================
# Elasticsearch-1
This Chart provides a basic Elasticsearch v1 search service.
========================================
==> Checking: elasticsearch-1...
--> Looking for label: app=elasticsearch-1
--> Looking for label: provider=elasticsearch-1
--> Looking for label: name=elasticsearch-1
--> Looking for label: app=elasticsearch-1
...
```

This changes the Pod template name to "elasticsearch-1" to meet the test expectations.
