### PR TITLE
fix(elasticsearch-1): name provider properly for tests

### DIFF
--- a/elasticsearch-1/manifests/elasticsearch-rc.yaml
+++ b/elasticsearch-1/manifests/elasticsearch-rc.yaml
@@ -11,7 +11,7 @@ spec:
     provider: elasticsearch-1
   template:
     metadata:
-      name: elasticsearch-1
+      name: elasticsearch
       labels:
         provider: elasticsearch-1
     spec:

--- a/elasticsearch-1/manifests/elasticsearch-rc.yaml
+++ b/elasticsearch-1/manifests/elasticsearch-rc.yaml
@@ -3,17 +3,17 @@ kind: ReplicationController
 metadata:
   name: elasticsearch
   labels:
-    provider: elasticsearch
+    provider: elasticsearch-1
     heritage: helm
 spec:
   replicas: 1
   selector:
-    provider: elasticsearch
+    provider: elasticsearch-1
   template:
     metadata:
       name: elasticsearch-1
       labels:
-        provider: elasticsearch
+        provider: elasticsearch-1
     spec:
       containers:
       - name: elasticsearch

--- a/elasticsearch-1/manifests/elasticsearch-svc.yaml
+++ b/elasticsearch-1/manifests/elasticsearch-svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: elasticsearch
   labels:
-    provider: elasticsearch
+    provider: elasticsearch-1
     heritage: helm
 spec:
   ports:
@@ -12,4 +12,4 @@ spec:
   - name: peer
     port: 9300
   selector:
-    provider: elasticsearch
+    provider: elasticsearch-1


### PR DESCRIPTION
The fix in #66 failed--my bad for not realizing `name:` wouldn't work and for not running the tests locally. This reverts that and instead makes a similar change to `provider:`.

I have tested this successfully in GKE using the `_test/test-charts` script. Thanks to @sgoings for helping me with the test setup.
