### PR TITLE
fix(riak/manifests/riak-rc.yaml): fix riak chart

### DIFF
--- a/riak/manifests/riak-rc.yaml
+++ b/riak/manifests/riak-rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: riak
-        image: quay.io/arschles/riak:devel
+        image: deis/riak
         env:
         - name:  RIAK_MASTER
           value: "1"

--- a/riak/manifests/riak-rc.yaml
+++ b/riak/manifests/riak-rc.yaml
@@ -11,10 +11,14 @@ spec:
     spec:
       containers:
       - name: riak
-        image: deis/riak
+        image: quay.io/arschles/riak:devel
         env:
         - name:  RIAK_MASTER
           value: "1"
+        - name: DEIS_RIAK_CLUSTER_SERVICE_HOST
+          value: "nothing" # if RIAK_MASTER is set to 1, this value is ignored
+        - name: DEIS_RIAK_CLUSTER_SERVICE_PORT
+          value: "1" # if RIAK_MASTER is set to 1, this value is ignored
         ports:
         - containerPort: 8087
         - containerPort: 8098


### PR DESCRIPTION
This PR at least runs Riak, but I'm noticing the following logs, which suggest that Riak may not be starting:

``` console
Starting Riak...
run_erl:615 [21] Mon Feb  8 18:52:13 2016
Erlang closed the connection.
started
```

The following are logs from `/var/log/riak/erlang.log.1`:

``` console
root@riak-fkeq3:/var/log/riak# cat erlang.log.1 

=====
===== LOGGING STARTED Mon Feb  8 18:52:10 UTC 2016
=====
18:52:12.073 [error] Error parsing /etc/riak/advanced.config: 17: syntax error before: 
Error generating config with cuttlefish
  run `riak config generate -l debug` for more information.
```

Fixes #68
Closes #69 
