### PR TITLE
Add a minecraft server chart

### DIFF
--- a/minecraft/Chart.yaml
+++ b/minecraft/Chart.yaml
@@ -1,0 +1,10 @@
+name: minecraft
+home: https://minecraft.net/
+version: 1.0.0
+description: A minecraft server
+maintainers:
+- Ben Barclay <benbarclay@gmail.com>
+details: |-
+  Minecraft is a moderately popular game involving the collection, moving and
+  re-assembling of raw materials. It may be an elaborate parody of the
+  Australian economy.

--- a/minecraft/README.md
+++ b/minecraft/README.md
@@ -1,0 +1,3 @@
+# minecraft
+
+This will run a minecraft server.

--- a/minecraft/manifests/minecraft-svc.yaml
+++ b/minecraft/manifests/minecraft-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minecraft
+  labels:
+    heritage: helm
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 25565
+    targetPort: 25565
+    protocol: TCP
+  selector:
+    app: minecraft

--- a/minecraft/manifests/minecraft.yaml
+++ b/minecraft/manifests/minecraft.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: minecraft-controller
+  labels:
+    heritage: helm
+spec:
+  replicas: 1
+  selector:
+    app: minecraft
+  template:
+    metadata:
+      labels:
+        heritage: helm
+        app: minecraft
+        scalable: false
+    spec:
+      containers:
+      - name: minecraft
+        image: "itzg/minecraft-server:latest"
+        ports: 
+        - containerPort: 25565
+        env:
+        - name: EULA
+          value: "TRUE"
+        volumeMounts:
+          - mountPath: /data
+            name: minecraft-data
+      volumes:
+        - name: minecraft-data
+          emptyDir: {}


### PR DESCRIPTION
Friends, I was saddened to see that Helm had no chart for a Minecraft server. Given that we are all invested in both Helm and Kubernetes, the most logical thing to do is to cash in on the popularity of Minecraft. Where it goes, millions of people follow.

That said, here is my attempt at a chart for it.
