### PR TITLE
feat(etcd): added etcd chart to helm charts

### DIFF
--- a/etcd/Chart.yaml
+++ b/etcd/Chart.yaml
@@ -1,0 +1,6 @@
+name: etcd
+home: https://coreos.com/etcd/ 
+version: 0.1.0
+description: etcd is a distributed key value store that provides a reliable way to store data across the cluster of kubernetes 
+maintainers:
+- Naga Ravi Chaitanya Elluri <nelluri@engineyard.com>

--- a/etcd/README.md
+++ b/etcd/README.md
@@ -1,0 +1,3 @@
+# etcd
+
+etcd is a distributed key value store that provides a reliable way to store data across the cluster of kubernetes.

--- a/etcd/manifests/etcd-controller.yaml
+++ b/etcd/manifests/etcd-controller.yaml
@@ -1,0 +1,58 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: etcd
+  heritage: helm
+  provider: etcd 
+spec:
+  strategy:
+    type: Recreate
+    resources: {}
+  triggers:
+  - type: ConfigChange
+  replicas: 3
+  selector:
+    name: etcd
+  template:
+    metadata:
+      labels:
+        name: etcd
+    spec:
+      containers:
+      - name: member
+        image: openshift/etcd-20-centos7
+        ports:
+        - containerPort: 2379
+          protocol: TCP
+        - containerPort: 2380
+          protocol: TCP
+        env:
+          # ETCD_NUM_MEMBERS is the maximum number of members to launch (have to match with # of replicas)
+        - name: ETCD_NUM_MEMBERS
+          value: "3"
+        - name: ETCD_INITIAL_CLUSTER_STATE
+          value: "new"
+          # ETCD_INITIAL_CLUSTER_TOKEN is a token etcd uses to generate unique cluster ID and member ID. Conforms to [a-z0-9]{40}
+        - name: ETCD_INITIAL_CLUSTER_TOKEN
+          value: INSERT_ETCD_INITIAL_CLUSTER_TOKEN
+          # ETCD_DISCOVERY_TOKEN is a unique token used by the discovery service. Conforms to etcd-cluster-[a-z0-9]{5}
+        - name: ETCD_DISCOVERY_TOKEN
+          value: INSERT_ETCD_DISCOVERY_TOKEN
+          # ETCD_DISCOVERY_URL connects etcd instances together by storing a list of peer addresses, 
+          # metadata and the initial size of the cluster under a unique address
+        - name: ETCD_DISCOVERY_URL
+          value: "http://etcd-discovery:2379"
+        - name: ETCDCTL_PEERS
+          value: "http://etcd:2379"
+        resources: {}
+        terminationMessagePath: "/dev/termination-log"
+        imagePullPolicy: IfNotPresent
+        capabilities: {}
+        securityContext:
+          capabilities: {}
+          privileged: false
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      serviceAccount: ''
+status: {}
+

--- a/etcd/manifests/etcd-discovery-controller.yaml
+++ b/etcd/manifests/etcd-discovery-controller.yaml
@@ -1,0 +1,42 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: etcd-discovery
+  creationTimestamp:
+  heritage: helm
+  provider: etcd 
+spec:
+  strategy:
+    type: Recreate
+    resources: {}
+  triggers:
+  - type: ConfigChange
+  replicas: 1
+  selector:
+    name: etcd-discovery
+  template:
+    metadata:
+      creationTimestamp: 
+      labels:
+        name: etcd-discovery
+    spec:
+      containers:
+      - name: discovery
+        image: openshift/etcd-20-centos7
+        args:
+        - etcd-discovery.sh
+        ports:
+        - containerPort: 2379
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: "/dev/termination-log"
+        imagePullPolicy: IfNotPresent
+        capabilities: {}
+        securityContext:
+          capabilities: {}
+          privileged: false
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      serviceAccount: ''
+status: {}
+

--- a/etcd/manifests/etcd-discovery-service.yaml
+++ b/etcd/manifests/etcd-discovery-service.yaml
@@ -1,0 +1,22 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: etcd-discovery
+  creationTimestamp: 
+  labels:
+    name: etcd-discovery
+    heritage: helm
+    provider: etcd
+spec:
+  ports:
+  - protocol: TCP
+    port: 2379
+    targetPort: 2379
+    nodePort: 0
+  selector:
+    name: etcd-discovery
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+

--- a/etcd/manifests/etcd-service.yaml
+++ b/etcd/manifests/etcd-service.yaml
@@ -1,0 +1,28 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: etcd
+  creationTimestamp: 
+  labels:
+    name: etcd
+    heritage: helm
+    provider: etcd
+spec:
+  ports:
+  - name: client
+    protocol: TCP
+    port: 2379
+    targetPort: 2379
+    nodePort: 0
+  - name: server
+    protocol: TCP
+    port: 2380
+    targetPort: 2380
+    nodePort: 0
+  selector:
+    name: etcd
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+


### PR DESCRIPTION
etcd chart for Kubernetes.
Tested etcd on Kubernetes deployed locally (AWS) using helm.
