### PR TITLE
feat(nodejs-mongo): added nodejs-mongo-stack chart to helm charts

### DIFF
--- a/nodejs-mongodb-stack/Chart.yaml
+++ b/nodejs-mongodb-stack/Chart.yaml
@@ -1,0 +1,8 @@
+name: nodejs-mongodb-stack
+home: http://meanjs.org/
+version: 0.1.0
+description: nodejs-mongodb-stack
+maintainers:
+- Naga Ravi Chaitanya Elluri <nelluri@deis.com>
+details:
+  Deploys a Node.js and MongoDB web stack on Kubernetes

--- a/nodejs-mongodb-stack/README.md
+++ b/nodejs-mongodb-stack/README.md
@@ -1,0 +1,3 @@
+# nodejs-mongodb-stack
+
+Deploys a Node.js and MongoDB web stack on Kubernetes. For more information refer to http://meanjs.org/.

--- a/nodejs-mongodb-stack/manifests/mongo-controller.yaml
+++ b/nodejs-mongodb-stack/manifests/mongo-controller.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    name: mongo
+    heritage: helm
+    provider: nodejs-mongodb
+  name: mongo-controller
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: mongo
+    spec:
+      containers:
+      - image: mongo:3.2.3
+        name: mongo
+        ports:
+        - name: mongo
+          containerPort: 27017
+          hostPort: 27017

--- a/nodejs-mongodb-stack/manifests/mongo-service.yaml
+++ b/nodejs-mongodb-stack/manifests/mongo-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mongo
+    heritage: helm
+    provider: nodejs-mongodb
+  name: mongo
+spec:
+  ports:
+    - port: 27017
+      targetPort: 27017
+  selector:
+    name: mongo

--- a/nodejs-mongodb-stack/manifests/web-controller.yaml
+++ b/nodejs-mongodb-stack/manifests/web-controller.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    name: web
+    heritage: helm
+    provider: nodejs-mongodb
+  name: web-controller
+spec:
+  replicas: 2
+  selector:
+    name: web
+  template:
+    metadata:
+      labels:
+        name: web
+    spec:
+      containers:
+      - image: meanjs/mean
+        name: web
+        ports:
+        - containerPort: 8080 
+          name: http-server

--- a/nodejs-mongodb-stack/manifests/web-service.yaml
+++ b/nodejs-mongodb-stack/manifests/web-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  labels:
+    name: web
+    heritage: helm
+    provider: nodejs-mongodb
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 3000
+      protocol: TCP
+  selector:
+    name: web


### PR DESCRIPTION
Chart to deploy nodejs-mongo web stack on Kubernetes.
