### PR TITLE
Fix broken label in minecraft replication controller

### DIFF
--- a/minecraft/README.md
+++ b/minecraft/README.md
@@ -1,3 +1,18 @@
-# minecraft
+# Minecraft
 
-This will run a minecraft server.
+This will run a standard [Minecraft](https://minecraft.net/) server.
+
+## Configuration
+
+This chart requires no configuration to use.
+
+## Scaling
+
+This server should not be scaled past a single instance.
+
+If you scale past a single instance you will be load balanced across several 
+different worlds. You will not be able to select which world you wish to play on.
+
+## Minecraft EULA
+
+By using this chart you implicitly agree to the Minecraft EULA.

--- a/minecraft/manifests/minecraft.yaml
+++ b/minecraft/manifests/minecraft.yaml
@@ -14,7 +14,6 @@ spec:
       labels:
         heritage: helm
         app: minecraft
-        scalable: false
     spec:
       containers:
       - name: minecraft


### PR DESCRIPTION
Leaving the boolean flag unquoted throws:

```
unable to load "STDIN": json: cannot unmarshal bool into Go value of type string
```

By quoting it, I can deploy.

Before:

```
bbarclay@bbarclay ~ $ helm install minecraft
---> Running `kubectl create -f` ...
service "minecraft" created

unable to load "STDIN": json: cannot unmarshal bool into Go value of type string
```

After:

```
bbarclay@bbarclay ~ $ helm install minecraft
---> Running `kubectl create -f` ...
service "minecraft" created

replicationcontroller "minecraft-controller" created

---> Done
```
