### PR TITLE
Fix Postgresql environment variable name for password

### DIFF
--- a/postgresql/manifests/postgresql-rc.yaml
+++ b/postgresql/manifests/postgresql-rc.yaml
@@ -16,7 +16,7 @@ spec:
       - name: postgres
         image: postgres
         env:
-        - name: DB_PASS
+        - name: POSTGRES_PASSWORD
           value: mypassword
         ports:
         - containerPort: 5432


### PR DESCRIPTION
Environment variable name of the password should be _POSTGRES_PASSWORD_ instead of _DB_PASS_.
See documentation [https://hub.docker.com/_/postgres/](https://hub.docker.com/_/postgres/)
