### PR TITLE
fix(tests): Fix broken chart uninstall

### DIFF
--- a/_test/lib.sh
+++ b/_test/lib.sh
@@ -63,10 +63,10 @@ function get-all-charts {
 
 function helmc::test-chart {
   log-warn "Start: ${1}"
-  .bin/helm fetch "${1}"
-  .bin/helm install "${1}"
-  helm::healthcheck "${1}"
-  .bin/helm uninstall -y "${1}"
+  .bin/helmc fetch "${1}"
+  .bin/helmc install "${1}" -n default
+  helmc::healthcheck "${1}"
+  .bin/helmc uninstall "${1}" -y -n default
   log-warn "Done: ${1}"
 }
 


### PR DESCRIPTION
Switch to `helmc`-- which was accidentally missed in a previous PR...

Also, even before that transition, these tests would have been failing for quite some time now, since `helm uninstall` (or now `helmc uninstall`) now _requires_ the `-n` flag to be specified with a value indicating the namespace the chart should be uninstalled _from_.  This has long been absent from the tests script in this repo.  CI hasn't caught that because CI doesn't run the full suite.
