### PR TITLE
fix(weavescope): Fix chart to pass tests

### DIFF
--- a/weavescope/manifests/scope-app-rc.yaml
+++ b/weavescope/manifests/scope-app-rc.yaml
@@ -3,14 +3,17 @@ kind: ReplicationController
 metadata:
   name: weave-scope-app
   labels:
-    provider: weave-scope-app
+    app: weave-scope-app
+    provider: weavescope
     heritage: helm
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        provider: weave-scope-app
+        app: weave-scope-app
+        provider: weavescope
+        heritage: helm
     spec:
       containers:
       - name: weave-scope-app

--- a/weavescope/manifests/scope-app-svc.yaml
+++ b/weavescope/manifests/scope-app-svc.yaml
@@ -3,11 +3,12 @@ kind: Service
 metadata:
   name: weave-scope-app
   labels:
-    provider: weave-scope-app
+    app: weave-scope-app
+    provider: weavescope
     heritage: helm
 spec:
   ports:
   - name: app
     port: 4040
   selector:
-    provider: weave-scope-app
+    app: weave-scope-app

--- a/weavescope/manifests/scope-probe-ds.yaml
+++ b/weavescope/manifests/scope-probe-ds.yaml
@@ -3,15 +3,17 @@ kind: DaemonSet
 metadata:
   name: weave-scope-probe
   labels:
+    app: weave-scope-probe
+    provider: weavescope
     heritage: helm
-    k8s-app:  weave-scope-probe
 spec:
   template:
     metadata:
-      name:  weave-scope-probe
+      name: weave-scope-probe
       labels:
+        app: weave-scope-probe
+        provider: weavescope
         heritage: helm
-        k8s-app:  weave-scope-probe
     spec:
       hostPID: true
       hostNetwork: true


### PR DESCRIPTION
The full test suite doesn't run during CI, but I discovered that the weavescope chart was not currently passing those tests if/when executed.

The reason is that the tests install each chart, then search for _any_ of the following labels on a pod:
- `app=${name}`
- `provider=${name}`
- `name=${name}`

Where `name` is `weavescope`, in this case.

This chart did not meet this requirement.

I have edited the chart such that `provider=weavescope`.  This _would_ break a selector on the service, so that selector was also edited to select `app=weave-scope-app` instead.

The chart now passes tests.
